### PR TITLE
clear stale users form lobby & small fix to state transitions

### DIFF
--- a/app.js
+++ b/app.js
@@ -49,6 +49,9 @@ var LM = require('./routes/modules/lobbyManager')(io);
 var GM = require('./routes/modules/gameManager');
 
 //TODO: remove all stale clients from lobby
+LM.removeStaleClients();
+
+
 io.sockets.on('connection', function (client) {
     client.emit('ClientJoined', { userId: client.id });
 

--- a/public/scripts/game.js
+++ b/public/scripts/game.js
@@ -102,7 +102,11 @@ var WalkingState = (function (_super) {
         var doneWalking = (unit.path.length === 0 && unit.moveTimer >= unit.moveSpeed);
 
         if (unit.newCommand && unit.moveTimer >= unit.moveSpeed) {
-            unit.ChangeState(WaitingState.Instance());
+            if (unit.command && unit.command.ToString() === "walk") {
+                unit.ChangeState(WalkingState.Instance());
+            } else if (unit.command && (unit.command.ToString() === "attack" || unit.command.ToString() === "engage")) {
+                unit.ChangeState(PursuingState.Instance());
+            }
         } else if (doneWalking) {
             unit.command = null;
             unit.ChangeState(WaitingState.Instance());
@@ -113,6 +117,7 @@ var WalkingState = (function (_super) {
 
     WalkingState.prototype.Exit = function (unit) {
         unit.prevLoc = unit.loc;
+        unit.newCommand = false;
     };
 
     WalkingState.move = function (unit) {

--- a/routes/modules/lobbyManager.js
+++ b/routes/modules/lobbyManager.js
@@ -18,6 +18,15 @@
     });
   }
 
+  this.removeStaleClients = function () {
+    sql.query( conn_str, "exec LobbyUser_RemoveAll", function ( err, results) {
+      if ( err ) {
+        console.log( err );
+        return;
+      }
+    });
+  }
+
 
   function broadcastClientList() {
     sql.query( conn_str, "exec dbo.User_GetAllInLobby", function ( err, results ) {

--- a/typescript/game/states/WalkingState.ts
+++ b/typescript/game/states/WalkingState.ts
@@ -27,7 +27,13 @@ class WalkingState extends State {
     var doneWalking: boolean = (unit.path.length === 0 && unit.moveTimer >= unit.moveSpeed);
     // the second half makes sure the unit has finished walking into the current grid location (otherwise graphics look werid)
     if (unit.newCommand && unit.moveTimer >= unit.moveSpeed) {
-      unit.ChangeState(WaitingState.Instance());
+      // if we recieve have a walk command, transition to walking
+      if (unit.command && unit.command.ToString() === "walk") {
+        unit.ChangeState(WalkingState.Instance());
+      } else if (unit.command && (unit.command.ToString() === "attack" || unit.command.ToString() === "engage")) {
+        // if we have an attack command, transition to pursuing
+        unit.ChangeState(PursuingState.Instance());
+      }
     } else if (doneWalking) {
       unit.command = null;
       unit.ChangeState(WaitingState.Instance());
@@ -38,6 +44,7 @@ class WalkingState extends State {
 
   public Exit(unit: Unit): void {
     unit.prevLoc = unit.loc;
+    unit.newCommand = false;
   }
 
   private static move(unit: Unit): void {


### PR DESCRIPTION
-when the server starts it wipes out all users in the lobby
-added a small change to how state transitions work so units don't
always transition to wait between walk commands (this probably needs to
be done smarter in the future)
